### PR TITLE
make >= assert info more accurate

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -129,7 +129,7 @@ local function validate_settings()
 
     if settings.timeout then
         assert(type(settings.timeout) == "number", "Timeout must be a number.")
-        assert(settings.timeout >= 100, "Timeout must be greater than 100.")
+        assert(settings.timeout >= 100, "Timeout must be greater than or equal to 100.")
     end
 
     assert(


### PR DESCRIPTION
The prev text would suggest, that values of 100 are not valid