### PR TITLE
Add note to readme.md about macro incompatibility (Closes #51)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,10 @@ This looks like this (see below for a gif):
 
 ## ✨Features
 
+> [!CAUTION]
+> Mappings configured with this plugin do not work with **macros**.
+> Use `<Esc>` to exit insert mode when recording macros instead.
+
 - Escape without getting delay when typing in insert mode
 - Customizable mapping and timeout
 - Use multiple mappings


### PR DESCRIPTION
I decided to use GitHub's new Markdown alerts feature to document this.

See the following link for details: https://github.com/orgs/community/discussions/16925

I wasn't sure what the best section was for this and put it under "Features".

We could potentially add a new "⚠️ Limitations" section instead.

![image](https://github.com/max397574/better-escape.nvim/assets/12969835/7d953335-8694-4411-9839-4358ff6e3bf8)
