### PR TITLE
fix: use return value of function as keys

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -139,7 +139,7 @@ local function map_keys()
                         if type(mapping) == "string" then
                             vim.api.nvim_input(mapping)
                         elseif type(mapping) == "function" then
-                            mapping()
+                            vim.api.nvim_input(mapping() or "")
                         end
                     end)
                 end


### PR DESCRIPTION
Fixes #63