### PR TITLE
fix: allow "bidirectional" mappings (e.g., kj and jk)

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -89,10 +89,13 @@ local function map_keys()
     for mode, keys in pairs(settings.mappings) do
         local map_opts = { expr = true }
         for key, subkeys in pairs(keys) do
-            vim.keymap.set(mode, key, function()
-                log_key(key)
-                return key
-            end, map_opts)
+            -- Ensure correct registration of bidirectional mappings (e.g., `kj` and `jk`). #67
+            if vim.fn.maparg(key, mode) == "" then
+                vim.keymap.set(mode, key, function()
+                    log_key(key)
+                    return key
+                end, map_opts)
+            end
             for subkey, mapping in pairs(subkeys) do
                 if mapping then
                     if not parent_keys[mode] then


### PR DESCRIPTION
Hello! This PR should fix the bug where only one of the "bidirectional" mappings (e.g., `kj` and `jk`) would be successfully registered. iiuc the current implementation processes those pairs of mappings as follows:

1. Given the following two mappings:
```lua
i = {
  j = { k = "<Esc>" },
  k = { j = "<Esc>" },
},
```
are to be registered with the `map_keys()` function.

2. Assuming that the `jk` combo gets registered first, it would be fine as `j` gets the mapping from the first `vim.keymap.set` and `k` from the second.

4. However, upon processing the `kj` combo, `k` gets overridden by the first `vim.keymap.set`, resulting in the first combo (`jk`) being broken.

This PR fixes this by checking if that key is already registered before the first `vim.keymap.set`. This works based on the following assumptions:

1. All relevant mappings are registered by `better-escape`, which is the case after calling `clear_mappings`. Plus, the plugin would break anyway if the user later overrides some of those mappings.

2. The second `vim.keymap.set` has the ability to detect if the key being inserted is also a starting key - this is implemented.

Hence imo this should work without any issues :D