### PR TITLE
fix: log the endkey not the startkey

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -114,7 +114,7 @@ local function map_keys()
                     end
                     -- Make sure we are in the correct sequence
                     if not parent_keys[mode][subkey][last_key] then
-                        log_key(key)
+                        log_key(subkey)
                         return subkey
                     end
                     vim.api.nvim_input(undo_key[mode] or "")


### PR DESCRIPTION
Fixes this bit of #73 

> unsure if this is related, but one additional thing ive discovered is that in visual mode, pressing j quickly will Esc back to normal mode even though the binding has been disabled, also, weirdly, pressing k consecutively will also Esc out even though that is not in the default config at al