### PR TITLE
refactor: add more comments and rename variables

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -54,7 +54,7 @@ end
 -- When a first_key is pressed, `recorded_key` is set to it 
 -- (e.g. if jk is a mapping, when 'j' is pressed, `recorded_key` is set to 'j')
 local recorded_key = nil 
-local bufmodified = false
+local bufmodified = nil
 local timeout_timer = uv.new_timer()
 local has_recorded = false -- See `vim.on_key` below
 local function record_key(key)


### PR DESCRIPTION
Since there were some bugs recently, and the code was hard to read, I decided to review it and
- Add more comments to make the code ~~human~~ more readable
- Renamed `key`             to `first_key`
- Renamed `subkey`          to `second_key`
- Renamed `recorded_key`    to `has_recorded`
- Renamed `last_key`        to `recorded_key`
- Renamed `parent_keys`     to `sequences` 
- Renamed `sequence_timer`  to `timeout_timer` 

- Renamed `log_key`         to `record_key`
- Removed a useless check in `record_key`
- Inverted the condition in `vim.on_key` to make it easier to read

TODO: fix: clear_mappings' position (Currently, it clears the mappings of the new config, not the old config)
TODO: move pcall to be inside of clear_mappings, so that it doesn't crash(stop deleting mappings) if mapping gets deleted twice (it gets deleted twice when it's a startkey and an endkey).
TODO: remove `sequences` because we can use the `settings.mappings` table instead.
I will do the `TODO:`s in other prs later.

@max397574, Since this is a breaking change for all other prs, if you are working on the plugin right now, don't merge this.
