### PR TITLE
fix: possibly unwanted keymap behaviour

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -147,7 +147,15 @@ local function map_keys()
                             false
                         )
                     elseif type(mapping) == "function" then
-                        vim.api.nvim_input(mapping() or "")
+                        vim.api.nvim_feedkeys(
+                            vim.api.nvim_replace_termcodes(
+                                mapping() or "",
+                                true,
+                                false,
+                                true
+                            ),
+                            "n",
+                            false)
                     end
                 end, map_opts)
                 ::continue::

--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -120,14 +120,32 @@ local function map_keys()
                         record_key(second_key)
                         return second_key
                     end
-                    vim.api.nvim_input(undo_key[mode] or "")
+                    vim.api.nvim_feedkeys(
+                        vim.api.nvim_replace_termcodes(
+                            undo_key[mode] or "",
+                            true,
+                            false,
+                            true
+                        ),
+                        "n",
+                        false
+                    )
                     vim.api.nvim_input(
                         ("<cmd>setlocal %smodified<cr>"):format(
                             bufmodified and "" or "no"
                         )
                     )
                     if type(mapping) == "string" then
-                        vim.api.nvim_input(mapping)
+                        vim.api.nvim_feedkeys(
+                            vim.api.nvim_replace_termcodes(
+                                mapping,
+                                true,
+                                false,
+                                true
+                            ),
+                            "n",
+                            false
+                        )
                     elseif type(mapping) == "function" then
                         vim.api.nvim_input(mapping() or "")
                     end


### PR DESCRIPTION
Hello!

I had the same (or similar) issue as in #68 but I thought that this is still unwanted behaviour, even if it is the intended behaviour. This PR changes the way the mapping input is handled so that even if there is a conflicting keymap, like using `<Esc>` for closing a completion window, it will still kick you back to Normal mode.

Below is a demonstration of the behaviour without the fix.
https://youtu.be/rX_D1S7NZCI
- It would work when there is no completion window (i.e. at the end of words)
- It wouldn't work when used after whitespace
  - If I spammed my chosen keymaps ("NE", because I use the Colemak keyboard layout), it wouldn't kick me back to Normal mode as expected.

Below is a demonstration of the behaviour with the fix.
https://youtu.be/UZS-a6Zsj1U

I'm unsure if this is the best solution because I am not experienced with lua and [`nvim_feedkeys`](https://neovim.io/doc/user/api.html#nvim_feedkeys()) is a blocking call instead of [`nvim_input`](https://neovim.io/doc/user/api.html#nvim_input())'s non-blocking asynchronous call.

Extra note: I observed that the default keymap "jk" worked perfectly fine with `default_keymaps = true`, so it may instead be an issue with how custom keymaps are handled.

