### PR TITLE
Fix: terminal mode defaults

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -26,8 +26,7 @@ local settings = {
         },
         t = {
             j = {
-                k = "<Esc>",
-                j = "<Esc>",
+                k = "<C-\\><C-n>",
             },
         },
         v = {


### PR DESCRIPTION
- For terminal-mode, change `<Esc>` to `<C-\><C-n>` because `<Esc>` doesn't exit terminal-mode by default.

- Refactor: Remove the "jj" terminal mapping because it gets misused with terminal apps that use vim-bindings, such as "less".