### PR TITLE
fix(cmd-mode): use <C-c> because <Esc> is technically bugged

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -20,8 +20,8 @@ local settings = {
         },
         c = {
             j = {
-                k = "<Esc>",
-                j = "<Esc>",
+                k = "<C-c>",
+                j = "<C-c>",
             },
         },
         t = {


### PR DESCRIPTION
In command-mode, `<Esc>` executes the command when called from a mapping. I don't remember why, but I think it was a bug.
Related Doc:
```
<Esc>		When typed and 'x' not present in 'cpoptions', quit
		Command-line mode without executing.  In macros or when 'x'
		present in 'cpoptions', start entered command.
		Note: If your <Esc> key is hard to hit on your keyboard, train
		yourself to use CTRL-[.
						*c_META* *c_ALT*
		ALT (|META|) may act like <Esc> if the chord is not mapped.
		For example <A-x> acts like <Esc>x if <A-x> does not have a
		command-line mode mapping.
							*c_CTRL-C*
CTRL-C		quit command-line without executing
```
fixes #107