### PR TITLE
feat: allow more than 2 keys

### DIFF
--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -115,9 +115,11 @@ local function map_final(mode, key, parents, action)
                 return key
             end
             local action = nil
+            local parent_length = 0
             for _, v in ipairs(parent_tree[mode][key]) do
                 -- compare the end of recorded_keys to every parent sequence
                 if v[1] == recorded_keys:sub(- #v[1]) then
+                    parent_length = #v[1]
                     action = v[2]
                     break
                 end
@@ -133,7 +135,7 @@ local function map_final(mode, key, parents, action)
             local keys = ""
             keys = keys
                 .. t(
-                    (undo_key[mode] or ""):rep(#parents)
+                    (undo_key[mode] or ""):rep(parent_length)
                     .. (
                         ("<cmd>setlocal %smodified<cr>"):format(
                             bufmodified and "" or "no"

--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -209,12 +209,16 @@ local function map_keys()
                 -- (e.g i = { jjk = "<Esc>" })
                 -- consider every key except the last as a parent ("jj" in the example above)
                 -- and map them
-                local sub_parents = parents .. (k:sub(1, #k - 1) or "")
-                for i = 1, #k - 1, 1 do
-                    local key = k:sub(i, i)
-                    map_parent(mode, key)
+                local has_special = vim.keycode(k) ~= k
+                local sub_parents = parents
+                if not has_special then
+                    sub_parents = parents .. (k:sub(1, #k - 1) or "")
+                    for i = 1, #k - 1, 1 do
+                        local key = k:sub(i, i)
+                        map_parent(mode, key)
+                    end
+                    k = k:sub(#k, #k)
                 end
-                k = k:sub(#k, #k)
 
                 if type(v) == "table" then
                     -- Handle subkeys

--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -133,7 +133,7 @@ local function map_final(mode, key, parents, action)
             local keys = ""
             keys = keys
                 .. t(
-                    (undo_key[mode] or ""):rep(#parent_tree[mode][key][1])
+                    (undo_key[mode] or ""):rep(#parents)
                     .. (
                         ("<cmd>setlocal %smodified<cr>"):format(
                             bufmodified and "" or "no"

--- a/lua/better_escape.lua
+++ b/lua/better_escape.lua
@@ -187,6 +187,16 @@ local function map_keys()
     end
 end
 
+-- TODO: update this
+local function unmap_keys()
+    for mode, keys in pairs(mapped_keys) do
+        for key, _ in pairs(mapped_keys) do
+            pcall(vim.keymap.del, key)
+        end
+    end
+    mapped_keys = {}
+end
+
 function M.setup(update)
     if update and update.default_mappings == false then
         settings.mappings = {}
@@ -214,6 +224,7 @@ function M.setup(update)
                 settings.keys
         end
     end
+    unmap_keys()
     map_keys()
 end
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ This also deprecated the `clear_empty_lines` setting. You can replicate this
 behavior by setting a mapping to a function like this:
 
 ```lua
--- `k` would be the second key of a mapping
+-- `k` would be the end key of a mapping
 k = function()
     vim.api.nvim_input("<esc>")
     local current_line = vim.api.nvim_get_current_line()
@@ -112,8 +112,8 @@ require("better_escape").setup {
     mappings = {
         -- mode = {
         --     firstkey = {
-        --        secondkey = "Escape key", -- make a key press "Escape key"
-        --        secondkey = false, -- disable a key
+        --        endkey = "Escape key", -- make a key press "Escape key"
+        --        endkey = false, -- disable a key
         --     },
         -- }
     }
@@ -134,6 +134,19 @@ mappings = {
             k = "<Esc>",
             j = "<Esc>",
         },
+        -- you can repeat this table pattern forever
+        -- map jjk to do nothing
+        j = {
+            j = {
+                k = "",
+            },
+        },
+        -- you can also define mappings with this shorthand
+        -- same as the example above, maps jk and jj to escape insert mode
+        jk = "", 
+        jj = "", 
+        -- same as the example above, maps jjk to do nothing
+        jjk = "", 
         -- disable jj
         j = {
             j = false,

--- a/readme.md
+++ b/readme.md
@@ -147,10 +147,15 @@ mappings = {
         jj = "", 
         -- same as the example above, maps jjk to do nothing
         jjk = "", 
-        -- NOTE:  The shorthand doesn't work if you use special characters
+        -- NOTE:  The shorthand doesn't work if you use special characters (<tab>, <c-x> <anything ..>)
         ["jj<Tab>"] = "<Esc>", -- doesn't escape
         -- Though you can use a mix of the shorthand and tables to use special characters:
         jj = {
+            ["<Tab>"] = "<Esc>",
+        },
+        -- NOTE: there's a bug where if a special character is not the final key in a mapping, then the plugin overdeletes characters
+        -- This is a limitation as the plugin can't tell if a special key needs to be deleted or not:
+        ["<Tab>"] = {
             ["<Tab>"] = "<Esc>",
         },
         

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,13 @@ mappings = {
         jj = "", 
         -- same as the example above, maps jjk to do nothing
         jjk = "", 
+        -- NOTE:  The shorthand doesn't work if you use special characters
+        ["jj<Tab>"] = "<Esc>", -- doesn't escape
+        -- Though you can use a mix of the shorthand and tables to use special characters:
+        jj = {
+            ["<Tab>"] = "<Esc>",
+        },
+        
         -- disable jj
         j = {
             j = false,


### PR DESCRIPTION
fixes #106 
Because you can make the preceded characters and set them to "" to disable the plugin:
```lua
v = {
    j = {
        j = {
            k = "",
        },
    }
},
```
This example fixes https://github.com/max397574/better-escape.nvim/issues/106#issuecomment-2607330551