### PR TITLE
fix: handle all first keys with empty_lines

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ behavior by setting a mapping to a function like this:
 k = function()
     vim.api.nvim_input("<esc>")
     local current_line = vim.api.nvim_get_current_line()
-    if current_line:match("^%s+j$") then
+    if current_line:match("^%s+.$") then
         vim.schedule(function()
             vim.api.nvim_set_current_line("")
         end)


### PR DESCRIPTION
fixes bug introduced in: 87c785ae8d4762762521562d024c018f48cf767e