### PR TITLE
Update better-escape.nvim setup example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,12 +28,7 @@ Use your favourite package manager and call the setup function.
 
 ```lua
 -- lua with lazy.nvim
-{
-  "max397574/better-escape.nvim",
-  config = function()
-    require("better_escape").setup()
-  end,
-}
+{ "max397574/better-escape.nvim", opts = {} }
 ```
 
 ## ❗Rewrite


### PR DESCRIPTION
Updated the lazy.nvim configuration example for better-escape.nvim to use opts. This is in line with the recommendation from the [documentation website](https://lazy.folke.io/developers).