### PR TITLE
Add basic loading unit tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        neovim_version: [stable, nightly]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.neovim_version }}
+      - name: Run tests
+        run: |
+          nvim --headless -u tests/minimal_init.lua \
+            -c "lua dofile('tests/test_better_escape.lua')"

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,9 @@
+-- Minimal init.lua for running tests in a headless Neovim instance.
+-- Usage: nvim --headless -u tests/minimal_init.lua
+
+-- Add the plugin to the runtime path
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+-- Disable swap files and shada for clean test runs
+vim.opt.swapfile = false
+vim.opt.shadafile = "NONE"

--- a/tests/test_better_escape.lua
+++ b/tests/test_better_escape.lua
@@ -1,0 +1,115 @@
+-- Tests for better-escape.nvim
+-- Run with: nvim --headless -u tests/minimal_init.lua -c "lua dofile('tests/test_better_escape.lua')"
+
+local be = require("better_escape")
+
+local passed = 0
+local failed = 0
+
+--- Simple test assertion helper.
+---@param name string
+---@param condition boolean
+---@param message? string
+local function assert_test(name, condition, message)
+    if condition then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. (message and (" — " .. message) or ""))
+    end
+end
+
+--- Run all tests.
+local function run_tests()
+    print("better-escape.nvim tests")
+    print(string.rep("=", 60))
+
+    -- Test: module loads correctly
+    print("\n[Module loading]")
+    assert_test("module returns a table", type(be) == "table")
+    assert_test("setup function exists", type(be.setup) == "function")
+    assert_test("waiting field exists", be.waiting ~= nil)
+    assert_test("waiting is initially false", be.waiting == false)
+
+    -- Test: setup with defaults
+    print("\n[Setup with defaults]")
+    be.setup()
+    assert_test("setup with no args does not error", true)
+    assert_test("waiting is false after setup", be.waiting == false)
+
+    -- Test: setup with custom config
+    print("\n[Setup with custom config]")
+    be.setup({
+        timeout = 100,
+        mappings = {
+            i = {
+                k = {
+                    j = "<Esc>",
+                },
+            },
+        },
+    })
+    assert_test("setup with custom config does not error", true)
+
+    -- Test: setup with default_mappings = false
+    print("\n[Setup with default_mappings = false]")
+    be.setup({
+        default_mappings = false,
+        mappings = {
+            i = {
+                j = {
+                    k = "<Esc>",
+                },
+            },
+        },
+    })
+    assert_test("setup with default_mappings=false does not error", true)
+
+    -- Test: setup with function mapping
+    print("\n[Setup with function mapping]")
+    be.setup({
+        mappings = {
+            i = {
+                j = {
+                    k = function()
+                        return "<Esc>"
+                    end,
+                },
+            },
+        },
+    })
+    assert_test("setup with function mapping does not error", true)
+
+    -- Test: setup with disabled mapping
+    print("\n[Setup with disabled mapping]")
+    be.setup({
+        mappings = {
+            i = {
+                j = {
+                    j = false,
+                },
+            },
+        },
+    })
+    assert_test("setup with disabled mapping does not error", true)
+
+    -- Summary
+    print("\n" .. string.rep("=", 60))
+    print(
+        string.format(
+            "Results: %d passed, %d failed, %d total",
+            passed,
+            failed,
+            passed + failed
+        )
+    )
+
+    if failed > 0 then
+        vim.cmd("cquit 1")
+    else
+        vim.cmd("quit")
+    end
+end
+
+run_tests()


### PR DESCRIPTION
Add basic loading unit tests and run them also in CI.

#### Example output
```
~/dev/better-escape.nvim 𝝺 nvim --headless -u tests/minimal_init.lua -c "lua dofile('tests/test_better_escape.lua')"
better-escape.nvim tests
============================================================

[Module loading]
  PASS: module returns a table
  PASS: setup function exists
  PASS: waiting field exists
  PASS: waiting is initially false

[Setup with defaults]
  PASS: setup with no args does not error
  PASS: waiting is false after setup

[Setup with custom config]
  PASS: setup with custom config does not error

[Setup with default_mappings = false]
  PASS: setup with default_mappings=false does not error

[Setup with function mapping]
  PASS: setup with function mapping does not error

[Setup with disabled mapping]
  PASS: setup with disabled mapping does not error

============================================================
Results: 10 passed, 0 failed, 10 total

```